### PR TITLE
Fix missing Stripe configuration

### DIFF
--- a/backend/mywnthub/settings.py
+++ b/backend/mywnthub/settings.py
@@ -10,6 +10,9 @@ SECRET_KEY = os.getenv("SECRET_KEY", "cambia_esto_en_producción")
 DEBUG = os.getenv("DEBUG", "True") == "True"
 ALLOWED_HOSTS = ["*"]
 
+# Stripe
+STRIPE_SECRET_KEY = os.getenv("STRIPE_SECRET_KEY", "")
+
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",


### PR DESCRIPTION
## Summary
- define `STRIPE_SECRET_KEY` in Django settings

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683f5e248720832683b0dc45fff51d7f